### PR TITLE
Bag fix with host resolving.

### DIFF
--- a/src/triton/Triton.hpp
+++ b/src/triton/Triton.hpp
@@ -27,7 +27,7 @@ enum ProtocolType { HTTP = 0, GRPC = 1 };
 class Triton : public ITriton {
 private:
     TritonClient triton_client_;
-    const std::string& url_; 
+    std::string url_; 
     bool verbose_; 
     ProtocolType protocol_;
     std::string model_name_;


### PR DESCRIPTION
Fix url_ field type.

If you use a non-localhost URL, and the Triton server is not located on localhost, the URL will not be recognized because of the type of field inside.