### PR TITLE
feat: consolidate vLLM text generation support

### DIFF
--- a/include/App.hpp
+++ b/include/App.hpp
@@ -38,6 +38,8 @@ private:
 
     void processVideoClassification(const std::string& sourceName);
 
+    void processTextGeneration(const TritonModelInfo& modelInfo);
+
     void renderPrediction(cv::Mat& frame, const vision_core::Result& prediction);
 
     void drawLabel(cv::Mat& image, const std::string& label, float confidence, int x, int y);
@@ -49,5 +51,6 @@ private:
 
     bool isImageFile(const std::string& filename);
     bool isVideoFile(const std::string& filename);
+    bool isTextGenerationModelType(const std::string& modelType);
     std::vector<std::string> split(const std::string& s, char delimiter);
 };

--- a/include/CommonTypes.hpp
+++ b/include/CommonTypes.hpp
@@ -13,7 +13,7 @@
 // Common types and lightweight includes that don't require heavy dependencies
 // Heavy dependencies like grpc_client.h should only be included where needed
 
-using TensorElement = std::variant<float, int32_t, int64_t, uint8_t>;
+using TensorElement = std::variant<float, int32_t, int64_t, uint8_t, std::string>;
 
 /**
  * @brief Tensor structure combining data and shape

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -142,7 +142,7 @@ public:
         log_file_ = v;
     }
 
-    // Multimodal (unused by tritonic but preserved for API compatibility)
+    // Multimodal and text-generation support
     bool GetEnableMultimodal() const noexcept {
         return enable_multimodal_;
     }
@@ -192,6 +192,37 @@ public:
         audio_weight_ = v;
     }
 
+    int GetMaxTokens() const noexcept {
+        return max_tokens_;
+    }
+    void SetMaxTokens(int v) noexcept {
+        max_tokens_ = v;
+    }
+    float GetTemperature() const noexcept {
+        return temperature_;
+    }
+    void SetTemperature(float v) noexcept {
+        temperature_ = v;
+    }
+    float GetTopP() const noexcept {
+        return top_p_;
+    }
+    void SetTopP(float v) noexcept {
+        top_p_ = v;
+    }
+    float GetRepetitionPenalty() const noexcept {
+        return repetition_penalty_;
+    }
+    void SetRepetitionPenalty(float v) noexcept {
+        repetition_penalty_ = v;
+    }
+    const std::string& GetStopWords() const noexcept {
+        return stop_words_;
+    }
+    void SetStopWords(const std::string& v) {
+        stop_words_ = v;
+    }
+
 private:
     std::string server_address_{"localhost"};
     int port_{8000};
@@ -226,4 +257,9 @@ private:
     float text_weight_{1.0f};
     float image_weight_{1.0f};
     float audio_weight_{1.0f};
+    int max_tokens_{256};
+    float temperature_{1.0f};
+    float top_p_{1.0f};
+    float repetition_penalty_{1.0f};
+    std::string stop_words_;
 };

--- a/src/main/App.cpp
+++ b/src/main/App.cpp
@@ -1,11 +1,88 @@
 #include "App.hpp"
+#include <cctype>
 #include <chrono>
 #include <deque>
 #include <filesystem>
+#include <fstream>
+#include <iostream>
 #include <random>
 #include <sstream>
 #include <thread>
 #include "vision-core/core/task_factory.hpp"
+
+namespace {
+std::string NormalizeModelType(const std::string& modelType) {
+    std::string normalized;
+    normalized.reserve(modelType.size());
+    for (char c : modelType) {
+        if (c != '-' && c != '_' && c != ' ') {
+            normalized += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        }
+    }
+    return normalized;
+}
+
+std::string ReadTextFile(const std::string& path) {
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        throw std::runtime_error("Could not open text input file: " + path);
+    }
+    return std::string(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+}
+
+std::string EscapeJsonString(const std::string& value) {
+    std::string escaped;
+    escaped.reserve(value.size());
+    for (char c : value) {
+        switch (c) {
+            case '\\':
+                escaped += "\\\\";
+                break;
+            case '"':
+                escaped += "\\\"";
+                break;
+            case '\n':
+                escaped += "\\n";
+                break;
+            case '\r':
+                escaped += "\\r";
+                break;
+            case '\t':
+                escaped += "\\t";
+                break;
+            default:
+                escaped += c;
+                break;
+        }
+    }
+    return escaped;
+}
+
+std::string BuildSamplingParameters(const InferenceConfig& config) {
+    std::ostringstream oss;
+    oss << "{\"max_tokens\":" << config.GetMaxTokens() << ",\"temperature\":"
+        << config.GetTemperature() << ",\"top_p\":" << config.GetTopP();
+    if (config.GetRepetitionPenalty() != 1.0f) {
+        oss << ",\"repetition_penalty\":" << config.GetRepetitionPenalty();
+    }
+    if (!config.GetStopWords().empty()) {
+        oss << ",\"stop\":[";
+        bool first = true;
+        std::istringstream stream(config.GetStopWords());
+        std::string word;
+        while (std::getline(stream, word, ',')) {
+            if (!first) {
+                oss << ',';
+            }
+            first = false;
+            oss << '"' << EscapeJsonString(word) << '"';
+        }
+        oss << ']';
+    }
+    oss << '}';
+    return oss.str();
+}
+}  // namespace
 
 App::App(std::shared_ptr<ITriton> triton, std::shared_ptr<InferenceConfig> config,
          std::shared_ptr<Logger> logger)
@@ -62,6 +139,13 @@ int App::run() {
         logger_->Info("Getting model info for: " + config_->GetModelName());
         TritonModelInfo modelInfo = tritonClient_->getModelInfo(
             config_->GetModelName(), config_->GetServerAddress(), config_->GetInputSizes());
+
+        if (isTextGenerationModelType(config_->GetModelType())) {
+            logger_->Info("Text-generation model detected: " + config_->GetModelType());
+            processTextGeneration(modelInfo);
+            logger_->Info("Application completed successfully");
+            return 0;
+        }
 
         // Create task instance
         logger_->Info("Creating task instance for model type: " + config_->GetModelType());
@@ -164,9 +248,89 @@ std::vector<vision_core::Result> App::processSource(const std::vector<cv::Mat>& 
     std::vector<vision_core::Tensor> vision_tensors;
     vision_tensors.reserve(tensors.size());
     for (const auto& tensor : tensors) {
-        vision_tensors.emplace_back(tensor.data, tensor.shape);
+        std::vector<vision_core::TensorElement> data;
+        data.reserve(tensor.data.size());
+        for (const auto& element : tensor.data) {
+            if (std::holds_alternative<float>(element)) {
+                data.emplace_back(std::get<float>(element));
+            } else if (std::holds_alternative<int32_t>(element)) {
+                data.emplace_back(std::get<int32_t>(element));
+            } else if (std::holds_alternative<int64_t>(element)) {
+                data.emplace_back(std::get<int64_t>(element));
+            } else if (std::holds_alternative<uint8_t>(element)) {
+                data.emplace_back(std::get<uint8_t>(element));
+            } else {
+                throw std::runtime_error(
+                    "String tensors are only supported by the text-generation path.");
+            }
+        }
+        vision_tensors.emplace_back(std::move(data), tensor.shape);
     }
     return task_->postprocess(cv::Size(source.front().cols, source.front().rows), vision_tensors);
+}
+
+bool App::isTextGenerationModelType(const std::string& modelType) {
+    const std::string normalized = NormalizeModelType(modelType);
+    return normalized == "vllm" || normalized == "llm" || normalized == "llama" ||
+           normalized == "mistral" || normalized == "qwen" || normalized == "phi" ||
+           normalized == "gemma" || normalized == "chatglm" ||
+           normalized == "textgeneration";
+}
+
+void App::processTextGeneration(const TritonModelInfo& modelInfo) {
+    std::string prompt = config_->GetTextPrompt();
+    if (prompt.empty() && !config_->GetTextInput().empty()) {
+        prompt = ReadTextFile(config_->GetTextInput());
+    }
+    if (prompt.empty()) {
+        prompt = config_->GetSource();
+    }
+    if (prompt.empty()) {
+        throw std::runtime_error(
+            "No text input provided. Use --text_prompt, --text_input, or --source.");
+    }
+
+    const std::string samplingParameters = BuildSamplingParameters(*config_);
+    logger_->Debug("Sampling parameters: " + samplingParameters);
+
+    std::vector<std::vector<std::string>> stringInputs;
+    stringInputs.reserve(modelInfo.input_names.size());
+
+    for (size_t i = 0; i < modelInfo.input_names.size(); ++i) {
+        const std::string& name = modelInfo.input_names[i];
+        if (name == "text_input" || name == "prompt") {
+            stringInputs.push_back({prompt});
+        } else if (name == "sampling_parameters") {
+            stringInputs.push_back({samplingParameters});
+        } else if (name == "stream") {
+            stringInputs.push_back({"false"});
+        } else if (name == "exclude_input_in_output") {
+            stringInputs.push_back({"true"});
+        } else if (name == "image" && config_->GetEnableMultimodal()) {
+            throw std::runtime_error(
+                "Multimodal image input is not supported in tritonic yet. "
+                "This requires upstream vision-core task contracts.");
+        } else {
+            stringInputs.push_back({""});
+        }
+    }
+
+    auto start = std::chrono::steady_clock::now();
+    const auto results = tritonClient_->inferText(stringInputs);
+    auto end = std::chrono::steady_clock::now();
+    const auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+
+    logger_->Info("Text generation completed in " + std::to_string(diff) + " ms");
+
+    for (const auto& tensor : results) {
+        for (const auto& element : tensor.data) {
+            if (std::holds_alternative<std::string>(element)) {
+                const std::string& text = std::get<std::string>(element);
+                logger_->Info("Generated text: " + text);
+                std::cout << text << std::endl;
+            }
+        }
+    }
 }
 
 void App::processImages(const std::vector<std::string>& sourceNames) {

--- a/src/main/App.cpp
+++ b/src/main/App.cpp
@@ -60,8 +60,8 @@ std::string EscapeJsonString(const std::string& value) {
 
 std::string BuildSamplingParameters(const InferenceConfig& config) {
     std::ostringstream oss;
-    oss << "{\"max_tokens\":" << config.GetMaxTokens() << ",\"temperature\":"
-        << config.GetTemperature() << ",\"top_p\":" << config.GetTopP();
+    oss << "{\"max_tokens\":" << config.GetMaxTokens()
+        << ",\"temperature\":" << config.GetTemperature() << ",\"top_p\":" << config.GetTopP();
     if (config.GetRepetitionPenalty() != 1.0f) {
         oss << ",\"repetition_penalty\":" << config.GetRepetitionPenalty();
     }
@@ -273,8 +273,7 @@ bool App::isTextGenerationModelType(const std::string& modelType) {
     const std::string normalized = NormalizeModelType(modelType);
     return normalized == "vllm" || normalized == "llm" || normalized == "llama" ||
            normalized == "mistral" || normalized == "qwen" || normalized == "phi" ||
-           normalized == "gemma" || normalized == "chatglm" ||
-           normalized == "textgeneration";
+           normalized == "gemma" || normalized == "chatglm" || normalized == "textgeneration";
 }
 
 void App::processTextGeneration(const TritonModelInfo& modelInfo) {

--- a/src/main/ConfigManager.cpp
+++ b/src/main/ConfigManager.cpp
@@ -58,7 +58,12 @@ std::unique_ptr<InferenceConfig> ConfigManager::LoadFromCommandLine(int argc, co
         "{modality_combination mc |concat | how to combine modalities}"
         "{text_weight tw |1.0   | weight for text modality}"
         "{image_weight iw |1.0  | weight for image modality}"
-        "{audio_weight aw |1.0  | weight for audio modality}";
+        "{audio_weight aw |1.0  | weight for audio modality}"
+        "{max_tokens mxt |256   | max tokens for LLM generation}"
+        "{temperature temp |1.0 | sampling temperature for LLM generation}"
+        "{top_p |1.0            | top-p sampling for LLM generation}"
+        "{repetition_penalty rp |1.0 | repetition penalty for LLM generation}"
+        "{stop_words sw |       | comma-separated stop words for LLM generation}";
 
     cv::CommandLineParser parser(argc, argv, keys);
 
@@ -92,6 +97,11 @@ std::unique_ptr<InferenceConfig> ConfigManager::LoadFromCommandLine(int argc, co
     config->SetTextWeight(parser.get<float>("text_weight"));
     config->SetImageWeight(parser.get<float>("image_weight"));
     config->SetAudioWeight(parser.get<float>("audio_weight"));
+    config->SetMaxTokens(parser.get<int>("max_tokens"));
+    config->SetTemperature(parser.get<float>("temperature"));
+    config->SetTopP(parser.get<float>("top_p"));
+    config->SetRepetitionPenalty(parser.get<float>("repetition_penalty"));
+    config->SetStopWords(parser.get<cv::String>("stop_words"));
 
     if (parser.has("input_sizes")) {
         std::string s = parser.get<cv::String>("input_sizes");

--- a/src/main/client.cpp
+++ b/src/main/client.cpp
@@ -53,6 +53,13 @@ int main(int argc, const char* argv[]) {
         logger->Info("  Verbose: " + std::string(config->GetVerbose() ? "true" : "false"));
         logger->Info("  Show Frame: " + std::string(config->GetShowFrame() ? "true" : "false"));
         logger->Info("  Write Frame: " + std::string(config->GetWriteFrame() ? "true" : "false"));
+        if (!config->GetTextPrompt().empty() || !config->GetTextInput().empty()) {
+            logger->Info("  Text Prompt: " + config->GetTextPrompt());
+            logger->Info("  Text Input: " + config->GetTextInput());
+            logger->Info("  Max Tokens: " + std::to_string(config->GetMaxTokens()));
+            logger->Info("  Temperature: " + std::to_string(config->GetTemperature()));
+            logger->Info("  Top-P: " + std::to_string(config->GetTopP()));
+        }
 
         // Create dependencies
         int port = config->GetPort();

--- a/src/triton/ITriton.hpp
+++ b/src/triton/ITriton.hpp
@@ -29,6 +29,12 @@ public:
     virtual std::vector<Tensor> infer(const std::vector<std::vector<uint8_t>>& input_data) = 0;
 
     /**
+     * Perform inference with string-based inputs for BYTES/STRING models.
+     */
+    virtual std::vector<Tensor> inferText(
+        const std::vector<std::vector<std::string>>& string_inputs) = 0;
+
+    /**
      * Set input shapes for dynamic shape models
      */
     virtual void setInputShapes(const std::vector<std::vector<int64_t>>& shapes) = 0;

--- a/src/triton/Triton.cpp
+++ b/src/triton/Triton.cpp
@@ -673,8 +673,7 @@ std::vector<Tensor> Triton::infer(const std::vector<std::vector<uint8_t>>& input
     return tensors;
 }
 
-std::vector<Tensor> Triton::inferText(
-    const std::vector<std::vector<std::string>>& string_inputs) {
+std::vector<Tensor> Triton::inferText(const std::vector<std::vector<std::string>>& string_inputs) {
     tc::Error err;
     std::vector<std::unique_ptr<tc::InferInput>> inputs;
     std::vector<std::unique_ptr<tc::InferRequestedOutput>> outputs;

--- a/src/triton/Triton.cpp
+++ b/src/triton/Triton.cpp
@@ -205,6 +205,10 @@ TritonModelInfo Triton::parseModelGrpc(const inference::ModelMetadataResponse& m
             info.input_types.push_back(CV_32S);
         } else if (datatype == "INT64") {
             info.input_types.push_back(CV_32S);  // Map INT64 to CV_32S
+        } else if (datatype == "BOOL") {
+            info.input_types.push_back(CV_8U);
+        } else if (datatype == "BYTES" || datatype == "STRING") {
+            info.input_types.push_back(TritonModelInfo::kStringTypeSentinel);
         } else {
             throw std::runtime_error("Unsupported data type: " + datatype);
         }
@@ -214,6 +218,15 @@ TritonModelInfo Triton::parseModelGrpc(const inference::ModelMetadataResponse& m
     // Outputs
     for (const auto& output : model_metadata.outputs()) {
         info.output_names.push_back(output.name());
+        std::string datatype = output.datatype();
+        if (datatype.rfind("TYPE_", 0) == 0)
+            datatype = datatype.substr(5);
+        info.output_datatypes.push_back(datatype);
+        std::vector<int64_t> shape;
+        for (const auto& dim : output.shape()) {
+            shape.push_back(dim);
+        }
+        info.output_shapes.push_back(shape);
     }
     return info;
 }
@@ -300,7 +313,9 @@ TritonModelInfo Triton::parseModelHttp(const std::string& modelName, const std::
         info.input_shapes.push_back(shape);
 
         std::string datatype = input["data_type"].GetString();
-        datatype.erase(0, 5);  // Remove the "TYPE_" prefix
+        if (datatype.rfind("TYPE_", 0) == 0) {
+            datatype.erase(0, 5);
+        }
         info.input_datatypes.push_back(datatype);
         if (datatype == "FP32") {
             info.input_types.push_back(CV_32F);
@@ -310,6 +325,10 @@ TritonModelInfo Triton::parseModelHttp(const std::string& modelName, const std::
             info.input_types.push_back(CV_32S);  // Map INT64 to CV_32S
             logger->Warn("Warning: INT64 type detected for input '" + info.input_names.back() +
                          "'. Will be mapped to CV_32S.");
+        } else if (datatype == "BOOL") {
+            info.input_types.push_back(CV_8U);
+        } else if (datatype == "BYTES" || datatype == "STRING") {
+            info.input_types.push_back(TritonModelInfo::kStringTypeSentinel);
         } else {
             throw std::runtime_error("Unsupported data type: " + datatype);
         }
@@ -319,6 +338,18 @@ TritonModelInfo Triton::parseModelHttp(const std::string& modelName, const std::
 
     for (const auto& output : responseJson["output"].GetArray()) {
         info.output_names.push_back(output["name"].GetString());
+        std::string datatype = output["data_type"].GetString();
+        if (datatype.rfind("TYPE_", 0) == 0) {
+            datatype.erase(0, 5);
+        }
+        info.output_datatypes.push_back(datatype);
+        std::vector<int64_t> shape;
+        if (output.HasMember("dims")) {
+            for (const auto& dim : output["dims"].GetArray()) {
+                shape.push_back(dim.GetInt64());
+            }
+        }
+        info.output_shapes.push_back(shape);
     }
 
     return info;
@@ -390,6 +421,16 @@ TritonModelInfo Triton::getModelInfo(const std::string& modelName, const std::st
 
 void Triton::updateInputTypes() {
     for (size_t i = 0; i < model_info_.input_shapes.size(); ++i) {
+        const auto& datatype = model_info_.input_datatypes[i];
+        if (datatype == "BYTES" || datatype == "STRING") {
+            model_info_.input_types[i] = TritonModelInfo::kStringTypeSentinel;
+            continue;
+        }
+        if (datatype == "BOOL") {
+            model_info_.input_types[i] = CV_8U;
+            continue;
+        }
+
         const auto& shape = model_info_.input_shapes[i];
         const auto& format = model_info_.input_formats[i];
 
@@ -524,6 +565,23 @@ std::vector<Tensor> Triton::getInferResults(tc::InferResult* result, const size_
             for (size_t i = 0; i < elementCount; ++i) {
                 infer_result.emplace_back(longData[i]);
             }
+        } else if (output_datatype == "BYTES" || output_datatype == "STRING") {
+            std::vector<std::string> stringData;
+            err = result->StringData(outputName, &stringData);
+            if (!err.IsOk()) {
+                throw std::runtime_error("Unable to get string data for " + outputName + ": " +
+                                         err.Message());
+            }
+            infer_result.reserve(stringData.size());
+            for (const auto& value : stringData) {
+                infer_result.emplace_back(value);
+            }
+        } else if (output_datatype == "BOOL") {
+            const uint8_t* boolData = reinterpret_cast<const uint8_t*>(outputData);
+            infer_result.reserve(outputByteSize);
+            for (size_t i = 0; i < outputByteSize; ++i) {
+                infer_result.emplace_back(boolData[i]);
+            }
         } else {
             throw std::runtime_error("Unsupported datatype: " + output_datatype);
         }
@@ -612,6 +670,94 @@ std::vector<Tensor> Triton::infer(const std::vector<std::vector<uint8_t>>& input
     result_ptr.reset(result);
 
     // Smart pointers automatically clean up inputs and outputs
+    return tensors;
+}
+
+std::vector<Tensor> Triton::inferText(
+    const std::vector<std::vector<std::string>>& string_inputs) {
+    tc::Error err;
+    std::vector<std::unique_ptr<tc::InferInput>> inputs;
+    std::vector<std::unique_ptr<tc::InferRequestedOutput>> outputs;
+
+    for (const auto& output_name : model_info_.output_names) {
+        tc::InferRequestedOutput* output;
+        err = tc::InferRequestedOutput::Create(&output, output_name);
+        if (!err.IsOk()) {
+            throw std::runtime_error("Unable to get output: " + err.Message());
+        }
+        outputs.emplace_back(output);
+    }
+
+    std::vector<const tc::InferRequestedOutput*> output_ptrs;
+    output_ptrs.reserve(outputs.size());
+    for (const auto& output : outputs) {
+        output_ptrs.push_back(output.get());
+    }
+
+    tc::InferOptions options(model_name_);
+    options.model_version_ = model_version_;
+
+    if (string_inputs.size() != model_info_.input_names.size()) {
+        throw std::runtime_error("Mismatch in number of inputs. Expected " +
+                                 std::to_string(model_info_.input_names.size()) + ", but got " +
+                                 std::to_string(string_inputs.size()));
+    }
+
+    for (size_t i = 0; i < model_info_.input_names.size(); ++i) {
+        tc::InferInput* input;
+        std::vector<int64_t> shape = model_info_.input_shapes[i];
+        if (shape.empty()) {
+            shape = {static_cast<int64_t>(string_inputs[i].size())};
+        }
+
+        err = tc::InferInput::Create(&input, model_info_.input_names[i], shape,
+                                     model_info_.input_datatypes[i]);
+        if (!err.IsOk()) {
+            throw std::runtime_error("Unable to create input " + model_info_.input_names[i] + ": " +
+                                     err.Message());
+        }
+        inputs.emplace_back(input);
+
+        const std::string& datatype = model_info_.input_datatypes[i];
+        if (datatype == "BYTES" || datatype == "STRING") {
+            err = input->AppendFromString(string_inputs[i]);
+        } else if (datatype == "BOOL") {
+            std::vector<uint8_t> bool_values;
+            bool_values.reserve(string_inputs[i].size());
+            for (const auto& value : string_inputs[i]) {
+                bool_values.push_back((value == "1" || value == "true" || value == "True") ? 1 : 0);
+            }
+            err = input->AppendRaw(bool_values);
+        } else {
+            throw std::runtime_error("inferText only supports BYTES/STRING/BOOL inputs, got " +
+                                     datatype + " for " + model_info_.input_names[i]);
+        }
+
+        if (!err.IsOk()) {
+            throw std::runtime_error("Failed setting input " + model_info_.input_names[i] + ": " +
+                                     err.Message());
+        }
+    }
+
+    std::vector<tc::InferInput*> input_ptrs;
+    input_ptrs.reserve(inputs.size());
+    for (const auto& input : inputs) {
+        input_ptrs.push_back(input.get());
+    }
+
+    tc::InferResult* result;
+    std::unique_ptr<tc::InferResult> result_ptr;
+    if (protocol_ == ProtocolType::HTTP) {
+        err = triton_client_.httpClient->Infer(&result, options, input_ptrs, output_ptrs);
+    } else {
+        err = triton_client_.grpcClient->Infer(&result, options, input_ptrs, output_ptrs);
+    }
+    if (!err.IsOk()) {
+        throw std::runtime_error("Failed sending synchronous infer request: " + err.Message());
+    }
+
+    auto tensors = getInferResults(result, model_info_.batch_size_, model_info_.output_names);
+    result_ptr.reset(result);
     return tensors;
 }
 
@@ -711,8 +857,11 @@ size_t Triton::calculateTensorSize(const std::vector<int64_t>& shape, const std:
         element_size = sizeof(int32_t);
     } else if (datatype == "INT64") {
         element_size = sizeof(int64_t);
-    } else if (datatype == "UINT8") {
+    } else if (datatype == "UINT8" || datatype == "BOOL") {
         element_size = sizeof(uint8_t);
+    } else if (datatype == "BYTES" || datatype == "STRING") {
+        throw std::runtime_error(
+            "BYTES/STRING inputs are not supported with shared memory inference.");
     } else {
         throw std::runtime_error("Unsupported datatype for shared memory: " + datatype);
     }

--- a/src/triton/Triton.hpp
+++ b/src/triton/Triton.hpp
@@ -182,6 +182,8 @@ public:
 
     void createTritonClient() override;
     std::vector<Tensor> infer(const std::vector<std::vector<uint8_t>>& input_data) override;
+    std::vector<Tensor> inferText(
+        const std::vector<std::vector<std::string>>& string_inputs) override;
     std::vector<Tensor> getInferResults(tc::InferResult* result, const size_t batch_size,
                                         const std::vector<std::string>& output_names);
 

--- a/src/triton/TritonModelInfo.hpp
+++ b/src/triton/TritonModelInfo.hpp
@@ -4,7 +4,11 @@
 #include <vector>
 
 struct TritonModelInfo {
+    static constexpr int kStringTypeSentinel = -1;
+
     std::vector<std::string> output_names;
+    std::vector<std::string> output_datatypes;
+    std::vector<std::vector<int64_t>> output_shapes;
     std::vector<std::string> input_names;
     std::vector<std::vector<int64_t>> input_shapes;
     std::vector<std::string> input_formats;

--- a/tests/mocks/MockTriton.hpp
+++ b/tests/mocks/MockTriton.hpp
@@ -16,6 +16,9 @@ public:
     MOCK_METHOD(std::vector<Tensor>, infer, (const std::vector<std::vector<uint8_t>>& input_data),
                 (override));
 
+    MOCK_METHOD(std::vector<Tensor>, inferText,
+                (const std::vector<std::vector<std::string>>& string_inputs), (override));
+
     MOCK_METHOD(void, setInputShapes, (const std::vector<std::vector<int64_t>>& shapes),
                 (override));
 

--- a/tests/unit/test_config.cpp
+++ b/tests/unit/test_config.cpp
@@ -24,6 +24,13 @@ TEST(InferenceConfigTest, DefaultValues) {
     EXPECT_EQ(config.GetLogLevel(), "info");
     EXPECT_TRUE(config.GetLogFile().empty());
     EXPECT_TRUE(config.GetInputSizes().empty());
+    EXPECT_FALSE(config.GetEnableMultimodal());
+    EXPECT_TRUE(config.GetTextPrompt().empty());
+    EXPECT_EQ(config.GetMaxTokens(), 256);
+    EXPECT_FLOAT_EQ(config.GetTemperature(), 1.0f);
+    EXPECT_FLOAT_EQ(config.GetTopP(), 1.0f);
+    EXPECT_FLOAT_EQ(config.GetRepetitionPenalty(), 1.0f);
+    EXPECT_TRUE(config.GetStopWords().empty());
 }
 
 TEST(InferenceConfigTest, ServerSettersGetters) {
@@ -171,4 +178,66 @@ TEST(ConfigManagerTest, ParsesConfidenceAndNms) {
     ASSERT_NE(config, nullptr);
     EXPECT_FLOAT_EQ(config->GetConfidenceThreshold(), 0.7f);
     EXPECT_FLOAT_EQ(config->GetNmsThreshold(), 0.3f);
+}
+
+TEST(InferenceConfigTest, MultimodalSettersGetters) {
+    InferenceConfig config;
+    config.SetEnableMultimodal(true);
+    config.SetTextInput("/tmp/prompt.txt");
+    config.SetAudioInput("/tmp/audio.wav");
+    config.SetTextPrompt("Describe this image");
+    config.SetModalityCombination("weighted");
+    config.SetTextWeight(0.5f);
+    config.SetImageWeight(0.8f);
+    config.SetAudioWeight(0.3f);
+
+    EXPECT_TRUE(config.GetEnableMultimodal());
+    EXPECT_EQ(config.GetTextInput(), "/tmp/prompt.txt");
+    EXPECT_EQ(config.GetAudioInput(), "/tmp/audio.wav");
+    EXPECT_EQ(config.GetTextPrompt(), "Describe this image");
+    EXPECT_EQ(config.GetModalityCombination(), "weighted");
+    EXPECT_FLOAT_EQ(config.GetTextWeight(), 0.5f);
+    EXPECT_FLOAT_EQ(config.GetImageWeight(), 0.8f);
+    EXPECT_FLOAT_EQ(config.GetAudioWeight(), 0.3f);
+}
+
+TEST(InferenceConfigTest, LlmSettersGetters) {
+    InferenceConfig config;
+    config.SetMaxTokens(512);
+    config.SetTemperature(0.7f);
+    config.SetTopP(0.9f);
+    config.SetRepetitionPenalty(1.2f);
+    config.SetStopWords("</s>,DONE");
+
+    EXPECT_EQ(config.GetMaxTokens(), 512);
+    EXPECT_FLOAT_EQ(config.GetTemperature(), 0.7f);
+    EXPECT_FLOAT_EQ(config.GetTopP(), 0.9f);
+    EXPECT_FLOAT_EQ(config.GetRepetitionPenalty(), 1.2f);
+    EXPECT_EQ(config.GetStopWords(), "</s>,DONE");
+}
+
+TEST(ConfigManagerTest, ParsesMultimodalAndLlmArgs) {
+    ConfigManager mgr;
+    const char* argv[] = {"tritonic",
+                          "--enable_multimodal=true",
+                          "--text_prompt=What is in this image?",
+                          "--text_input=/tmp/prompt.txt",
+                          "--audio_input=/tmp/audio.wav",
+                          "--max_tokens=128",
+                          "--temperature=0.5",
+                          "--top_p=0.8",
+                          "--repetition_penalty=1.1",
+                          "--stop_words=</s>,DONE"};
+    int argc = sizeof(argv) / sizeof(argv[0]);
+    auto config = mgr.LoadFromCommandLine(argc, argv);
+    ASSERT_NE(config, nullptr);
+    EXPECT_TRUE(config->GetEnableMultimodal());
+    EXPECT_EQ(config->GetTextPrompt(), "What is in this image?");
+    EXPECT_EQ(config->GetTextInput(), "/tmp/prompt.txt");
+    EXPECT_EQ(config->GetAudioInput(), "/tmp/audio.wav");
+    EXPECT_EQ(config->GetMaxTokens(), 128);
+    EXPECT_FLOAT_EQ(config->GetTemperature(), 0.5f);
+    EXPECT_FLOAT_EQ(config->GetTopP(), 0.8f);
+    EXPECT_FLOAT_EQ(config->GetRepetitionPenalty(), 1.1f);
+    EXPECT_EQ(config->GetStopWords(), "</s>,DONE");
 }

--- a/tests/unit/test_triton_interface.cpp
+++ b/tests/unit/test_triton_interface.cpp
@@ -41,5 +41,32 @@ TEST(TritonInterfaceTest, TritonModelInfoHasExpectedFields) {
     EXPECT_EQ(modelInfo.max_batch_size_, 1);
 }
 
+TEST(TritonInterfaceTest, TritonModelInfoStoresOutputMetadata) {
+    TritonModelInfo modelInfo;
+    modelInfo.output_names = {"text_output"};
+    modelInfo.output_datatypes = {"BYTES"};
+    modelInfo.output_shapes = {{-1}};
+    modelInfo.input_datatypes = {"BYTES", "BOOL"};
+    modelInfo.input_types = {TritonModelInfo::kStringTypeSentinel, CV_8U};
+
+    EXPECT_EQ(modelInfo.output_datatypes[0], "BYTES");
+    EXPECT_EQ(modelInfo.output_shapes[0][0], -1);
+    EXPECT_EQ(modelInfo.input_types[0], TritonModelInfo::kStringTypeSentinel);
+    EXPECT_EQ(modelInfo.input_types[1], CV_8U);
+}
+
+TEST(TensorElementTest, SupportsStringVariant) {
+    TensorElement element = std::string("hello");
+    EXPECT_TRUE(std::holds_alternative<std::string>(element));
+    EXPECT_EQ(std::get<std::string>(element), "hello");
+}
+
+TEST(TensorTest, StoresStringData) {
+    Tensor tensor({std::string("generated text")}, {1});
+    ASSERT_EQ(tensor.data.size(), 1u);
+    EXPECT_TRUE(std::holds_alternative<std::string>(tensor.data[0]));
+    EXPECT_EQ(std::get<std::string>(tensor.data[0]), "generated text");
+}
+
 // Note: Concrete Triton class tests should be in integration tests
 // where heavy dependencies are acceptable


### PR DESCRIPTION
## Summary
- consolidate the useful Copilot vLLM/text-generation work into one branch
- add explicit `inferText()` support for BYTES/STRING Triton inputs and outputs
- add a text-generation app path that bypasses `vision-core` until upstream multimodal contracts exist
- add config surface and unit coverage for LLM generation parameters

## Notes
- keeps existing vision-task flow intact by isolating string tensors to the text-generation path
- does not implement full multimodal image+text support yet; that still requires upstream `vision-core` contract work
- supersedes draft Copilot PRs #7, #8, and #9

## Evidence
- `cmake --build build-ci --parallel 4`
- `ctest --test-dir build-ci --output-on-failure`
- Result: 37/37 tests passed